### PR TITLE
Simplify lib folder structure

### DIFF
--- a/R/get.pkg_search_paths.R
+++ b/R/get.pkg_search_paths.R
@@ -15,27 +15,14 @@
 #' }
 #'
 get.pkg_search_paths <- function(pkg, vrs) {
-  # R versions
-  R.toc <- toc("R")
 
-  R_vrs <- do.call(rbind.data.frame, strsplit(R.toc$Version, ".", fixed = TRUE))
-  names(R_vrs) <- c("major", "minor", "patch")
+  rv <- as.character(getRversion())
 
-  R.toc <- cbind(R.toc, R_vrs)
-
-  R.toc$Published <- as.DateYMD(R.toc$Published)
-
-  # Subset of R.toc for same minor as r.using
-  rv <- r.version.check("2019-01-01") # use arbitrary date for we don't use 'r.need', just r.using
-  subset.R.toc <- R.toc[R.toc$minor == rv$r.using.minor &
-    R.toc$major == rv$r.using.major &
-    R.toc$Published <= get.rdate(), ]
-
-  # Sort versions from most recent
-  subset.R.toc <- subset.R.toc[order(subset.R.toc$Published, decreasing = TRUE), ]
+  # Get rid of patch version number
+  rv <- gsub("\\.\\d+(-w)?$", "", rv)
 
   # paths
-  pkg_search_paths <- paste0(get.groundhog.folder(), "/R-", subset.R.toc$Version, "/", pkg, "_", vrs)
+  pkg_search_paths <- paste0(get.groundhog.folder(), "/R-", rv, "/", pkg, "_", vrs)
 
   # Ensure directories exist
   return(pkg_search_paths)

--- a/R/get.snowball.R
+++ b/R/get.snowball.R
@@ -51,6 +51,9 @@ get.snowball <- function(pkg, date, include.suggests = FALSE, force.source = FAL
 
   snowball.installed <- mapply(is.pkg_vrs.installed, snowball.pkg, snowball.vrs) # 5.1 Installed?  TRUE/FALSE
 
+  # Vector with paths
+  snowball.installation.path <- mapply(get.pkg_search_paths, snowball.pkg, snowball.vrs)
+
   # No need to find the locations if everything is already installed. This also
   # allows us to run offline in easy cases
   if (all(snowball.installed)) {
@@ -63,7 +66,7 @@ get.snowball <- function(pkg, date, include.suggests = FALSE, force.source = FAL
         "from" =  NA_character_, # Where to install from
         "MRAN.date" = NA_character_, # MRAN date, in case MRAN is tried
         "installation.time" = NA_real_, # time to install
-        "installation.path" = NA_character_,
+        "installation.path" = snowball.installation.path,
         stringsAsFactors = FALSE
       )
     )
@@ -92,20 +95,6 @@ get.snowball <- function(pkg, date, include.suggests = FALSE, force.source = FAL
   # Adjust installation time
   adjustment <- 2.5 # install times in CRAN's page are systematically too long, this is an initial adjustment factor
   snowball.time <- pmax(round(snowball.time / adjustment, 0), 1)
-
-  # Installation path
-  # Only r.path portion differs across where the package is obtained
-  r.path <- vapply(seq_along(snowball.pkg), function(k) {
-    switch(
-      snowball.from[k],
-      "MRAN" = get.version("R", snowball.MRAN.date[k]),
-      "CRAN" = max(toc("R")$Version),
-      "source" = get.rversion()
-    )
-  }, character(1))
-
-  # Vector with paths
-  snowball.installation.path <- paste0(get.groundhog.folder(), "/R-", r.path, "/", snowball.pkg_vrs)
 
   # data.frame()
   snowball <- data.frame(

--- a/tests/testthat/test-paths.R
+++ b/tests/testthat/test-paths.R
@@ -32,7 +32,10 @@ test_that("set.groundhog.folder", {
 
 test_that("get.pkg_search_paths()", {
 
-  expect_is(get.pkg_search_paths("magrittr", "1.0.1"), "character")
+  p <- get.pkg_search_paths("magrittr", "1.0.1")
+
+  expect_type(p, "character")
+  exepct_length(p, 1)
 
 })
 


### PR DESCRIPTION
To use major.minor instead of major.minor.patch. This behaviour is consistent with the way base R library is organised.

@urisohn, is this what you had in mind? Or did you think about something different?